### PR TITLE
Changed module path to tiswanso/networkservicemesh

### DIFF
--- a/controllers/sriov-controller/go.mod
+++ b/controllers/sriov-controller/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/controllers/sriov-controller
+module github.com/tiswanso/networkservicemesh/controllers/sriov-controller
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/controlplane/api/go.mod
+++ b/controlplane/api/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/controlplane/api
+module github.com/tiswanso/networkservicemesh/controlplane/api
 
 require (
 	github.com/golang/protobuf v1.3.2

--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -1,8 +1,9 @@
-module github.com/networkservicemesh/networkservicemesh/controlplane
+module github.com/tiswanso/networkservicemesh/controlplane
 
 require (
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/golang/protobuf v1.3.2
+	github.com/networkservicemesh/networkservicemesh/controlplane v0.0.0-00010101000000-000000000000
 	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
 	github.com/networkservicemesh/networkservicemesh/forwarder/api v0.2.0
 	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0

--- a/forwarder/api/go.mod
+++ b/forwarder/api/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/forwarder/api
+module github.com/tiswanso/networkservicemesh/forwarder/api
 
 require (
 	github.com/golang/protobuf v1.3.2

--- a/forwarder/go.mod
+++ b/forwarder/go.mod
@@ -1,10 +1,11 @@
-module github.com/networkservicemesh/networkservicemesh/forwarder
+module github.com/tiswanso/networkservicemesh/forwarder
 
 require (
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/golang/protobuf v1.3.2
 	github.com/ligato/vpp-agent v2.3.0+incompatible
 	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/forwarder v0.0.0-00010101000000-000000000000
 	github.com/networkservicemesh/networkservicemesh/forwarder/api v0.2.0
 	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
 	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh
+module github.com/tiswanso/networkservicemesh
 
 replace (
 	// ./scripts/switch_k8s_version.sh to change k8s version

--- a/k8s/api/go.mod
+++ b/k8s/api/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/k8s/api
+module github.com/tiswanso/networkservicemesh/k8s/api
 
 require (
 	github.com/golang/protobuf v1.3.2

--- a/k8s/go.mod
+++ b/k8s/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/k8s
+module github.com/tiswanso/networkservicemesh/k8s
 
 require (
 	github.com/caddyserver/caddy v1.0.3
@@ -9,6 +9,7 @@ require (
 	github.com/miekg/dns v1.1.15
 	github.com/networkservicemesh/networkservicemesh/controlplane v0.2.0
 	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/k8s v0.0.0-00010101000000-000000000000
 	github.com/networkservicemesh/networkservicemesh/k8s/api v0.2.0
 	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
 	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0
@@ -61,7 +62,8 @@ replace (
 	github.com/networkservicemesh/networkservicemesh/controlplane/api => ../controlplane/api
 	github.com/networkservicemesh/networkservicemesh/forwarder => ../forwarder
 	github.com/networkservicemesh/networkservicemesh/forwarder/api => ../forwarder/api
-	github.com/networkservicemesh/networkservicemesh/k8s/api => ../k8s/api
+	github.com/networkservicemesh/networkservicemesh/k8s => ./
+	github.com/networkservicemesh/networkservicemesh/k8s/api => ./api
 	github.com/networkservicemesh/networkservicemesh/pkg => ../pkg
 	github.com/networkservicemesh/networkservicemesh/sdk => ../sdk
 	github.com/networkservicemesh/networkservicemesh/side-cars => ../side-cars

--- a/k8s/go.sum
+++ b/k8s/go.sum
@@ -15,6 +15,7 @@ github.com/Azure/go-autorest/autorest/validation v0.1.0/go.mod h1:Ha3z/SqBeaalWQ
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/pkg
+module github.com/tiswanso/networkservicemesh/pkg
 
 go 1.12
 

--- a/scripts/aws/go.mod
+++ b/scripts/aws/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/scripts/aws
+module github.com/tiswanso/networkservicemesh/scripts/aws
 
 require (
 	github.com/aws/aws-sdk-go v1.23.19

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/sdk
+module github.com/tiswanso/networkservicemesh/sdk
 
 require (
 	github.com/fsnotify/fsnotify v1.4.7

--- a/side-cars/go.mod
+++ b/side-cars/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/side-cars
+module github.com/tiswanso/networkservicemesh/side-cars
 
 require (
 	github.com/networkservicemesh/networkservicemesh/controlplane v0.2.0
@@ -6,6 +6,7 @@ require (
 	github.com/networkservicemesh/networkservicemesh/k8s/api v0.2.0
 	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
 	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0
+	github.com/networkservicemesh/networkservicemesh/side-cars v0.0.0-00010101000000-000000000000
 	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/sirupsen/logrus v1.4.2

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/test
+module github.com/tiswanso/networkservicemesh/test
 
 require (
 	github.com/fsnotify/fsnotify v1.4.7
@@ -15,6 +15,7 @@ require (
 	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
 	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0
 	github.com/networkservicemesh/networkservicemesh/side-cars v0.2.0
+	github.com/networkservicemesh/networkservicemesh/test v0.0.0-00010101000000-000000000000
 	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/packethost/packngo v0.1.1-0.20190507131943-1343be729ca2

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,4 +1,4 @@
-module github.com/networkservicemesh/networkservicemesh/utils
+module github.com/tiswanso/networkservicemesh/utils
 
 require (
 	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0


### PR DESCRIPTION
After merging the code we need to tag it to v0.1.0:
git tag v0.1.0 controllers/sriov-controller/v0.1.0 controlplane/api/v0.1.0 forwarder/api/v0.1.0 forwarder/v0.1.0 k8s/api/v0.1.0 k8s/v0.1.0 pkg/v0.1.0  scripts/aws/v0.1.0 sdk/v0.1.0 side-cars/v0.1.0 test/v0.1.0 utils/v0.1.0
