### PR TITLE
NSM forwarder fix: add ability to set client interface MTU

### DIFF
--- a/controlplane/api/connection/mechanisms/common/constants.go
+++ b/controlplane/api/connection/mechanisms/common/constants.go
@@ -16,4 +16,7 @@ const (
 	InterfaceNameKey = "name"
 	// InterfaceDescriptionKey - interface description mechanism property key
 	InterfaceDescriptionKey = "description"
+
+	// MTUOverhead - MTU overhead of a mechanism
+	MTUOverhead = "mtu_overhead"
 )

--- a/controlplane/api/connection/mechanisms/common/helpers.go
+++ b/controlplane/api/connection/mechanisms/common/helpers.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"net"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -38,4 +39,29 @@ func getIPParameter(m *connection.Mechanism, name string) (string, error) {
 	}
 
 	return ip, nil
+}
+
+// SetMTUOverhead sets the MTU overhead parameter in the parameter map
+func SetMTUOverhead(parameters map[string]string, mtu uint32) error {
+	if parameters == nil {
+		return errors.Errorf("mechanism parameters cannot be nil")
+	}
+	parameters[MTUOverhead] = strconv.FormatUint(uint64(mtu), 10)
+	return nil
+}
+
+// GetMTUOverhead returns the MTU overhead parameter value from the parameter map
+func GetMTUOverhead(parameters map[string]string) (uint32, error) {
+	if parameters == nil {
+		return 0, errors.Errorf("mechanism parameters cannot be nil")
+	}
+	overheadParam, ok := parameters[MTUOverhead]
+	if !ok {
+		return 0, nil // parameter not found - return 0
+	}
+	overhead, err := strconv.Atoi(overheadParam)
+	if err != nil {
+		return 0, errors.Errorf("cannot convert mechanism.Parameters[%s] to number: %v", MTUOverhead, err)
+	}
+	return uint32(overhead), nil
 }

--- a/controlplane/api/connection/mechanisms/common/helpers.go
+++ b/controlplane/api/connection/mechanisms/common/helpers.go
@@ -41,8 +41,16 @@ func getIPParameter(m *connection.Mechanism, name string) (string, error) {
 	return ip, nil
 }
 
+// SetMTUOverhead sets the MTU overhead parameter in the mechanism
+func SetMTUOverhead(m *connection.Mechanism, mtu uint32) error {
+	if m == nil {
+		return errors.New("mechanism cannot be nil")
+	}
+	return SetMTUOverheadParameter(m.Parameters, mtu)
+}
+
 // SetMTUOverhead sets the MTU overhead parameter in the parameter map
-func SetMTUOverhead(parameters map[string]string, mtu uint32) error {
+func SetMTUOverheadParameter(parameters map[string]string, mtu uint32) error {
 	if parameters == nil {
 		return errors.Errorf("mechanism parameters cannot be nil")
 	}
@@ -50,12 +58,15 @@ func SetMTUOverhead(parameters map[string]string, mtu uint32) error {
 	return nil
 }
 
-// GetMTUOverhead returns the MTU overhead parameter value from the parameter map
-func GetMTUOverhead(parameters map[string]string) (uint32, error) {
-	if parameters == nil {
+// GetMTUOverhead returns the MTU overhead value from the mechanism
+func GetMTUOverhead(m *connection.Mechanism) (uint32, error) {
+	if m == nil {
+		return 0, errors.New("mechanism cannot be nil")
+	}
+	if m.Parameters == nil {
 		return 0, errors.Errorf("mechanism parameters cannot be nil")
 	}
-	overheadParam, ok := parameters[MTUOverhead]
+	overheadParam, ok := m.Parameters[MTUOverhead]
 	if !ok {
 		return 0, nil // parameter not found - return 0
 	}

--- a/controlplane/api/connection/mechanisms/srv6/constant.go
+++ b/controlplane/api/connection/mechanisms/srv6/constant.go
@@ -43,4 +43,7 @@ const (
 	SrcHardwareAddress = "src_hw_addr"
 	// DstHardwareAddress - dst hw address
 	DstHardwareAddress = "dst_hw_addr"
+
+	// MTUOverhead - maximum transmission unit overhead for SRv6 encapsulation
+	MTUOverhead = 40 // TODO: verify: this accomodates SRv6 header (8 bytes) + 2 SID IP (32 bytes)
 )

--- a/controlplane/api/connection/mechanisms/vxlan/constant.go
+++ b/controlplane/api/connection/mechanisms/vxlan/constant.go
@@ -19,4 +19,7 @@ const (
 	DstExternalIP = common.DstExternalIP
 	// VNI - vni
 	VNI = "vni"
+
+	// MTUOverhead - maximum transmission unit overhead for VXLAN encapsulation
+	MTUOverhead = 50
 )

--- a/controlplane/api/connection/mechanisms/wireguard/constant.go
+++ b/controlplane/api/connection/mechanisms/wireguard/constant.go
@@ -50,4 +50,7 @@ const (
 	DstPublicKey = "dst_public_key"
 	// DstPrivateKey - Source private key
 	DstPrivateKey = "dst_private_key"
+
+	// MTUOverhead - maximum transmission unit overhead for Wireguard encapsulation
+	MTUOverhead = 75 // TODO: verify (https://lists.zx2c4.com/pipermail/wireguard/2019-July/004289.html)
 )

--- a/controlplane/api/connectioncontext/const.go
+++ b/controlplane/api/connectioncontext/const.go
@@ -5,4 +5,7 @@ const (
 	DNSConfigShouldNotBeNil = "dnsConfig should not be nil"
 	//DNSServerIpsShouldHaveRecords -
 	DNSServerIpsShouldHaveRecords = "dnsConfig should have records"
+
+	// MTUOverhead - MTU overhead requested in the connection
+	MTUOverhead = "mtu_overhead"
 )

--- a/controlplane/api/connectioncontext/helpers.go
+++ b/controlplane/api/connectioncontext/helpers.go
@@ -2,6 +2,7 @@ package connectioncontext
 
 import (
 	"net"
+	"strconv"
 
 	"github.com/pkg/errors"
 )
@@ -107,4 +108,35 @@ func (c *ExtraPrefixRequest) IsValid() error {
 	}
 
 	return nil
+}
+
+// SetMTUOverhead sets the MTU overhead in the connection context
+func (c *ConnectionContext) SetMTUOverhead(mtu uint32) error {
+	if c == nil {
+		return errors.New("ConnectionContext should not be nil")
+	}
+	if c.ExtraContext == nil {
+		c.ExtraContext = make(map[string]string)
+	}
+	c.ExtraContext[MTUOverhead] = strconv.FormatUint(uint64(mtu), 10)
+	return nil
+}
+
+// GetMTUOverhead returns the MTU overhead value from the connection context
+func (c *ConnectionContext) GetMTUOverhead() (uint32, error) {
+	if c == nil {
+		return 0, errors.New("ConnectionContext should not be nil")
+	}
+	if c.ExtraContext == nil {
+		return 0, nil
+	}
+	overheadParam, ok := c.ExtraContext[MTUOverhead]
+	if !ok {
+		return 0, nil // parameter not found - return 0
+	}
+	overhead, err := strconv.Atoi(overheadParam)
+	if err != nil {
+		return 0, errors.Errorf("cannot convert ConnectionContext.ExtraContext[%s] to number: %v", MTUOverhead, err)
+	}
+	return uint32(overhead), nil
 }

--- a/controlplane/pkg/local/forwarder_service.go
+++ b/controlplane/pkg/local/forwarder_service.go
@@ -158,7 +158,7 @@ func (cce *forwarderService) prepareSRv6Mechanism(m *connection.Mechanism, reque
 	parameters[srv6.SrcBSID] = cce.serviceRegistry.SIDAllocator().SID(request.Connection.GetId())
 	parameters[srv6.SrcLocalSID] = cce.serviceRegistry.SIDAllocator().SID(request.Connection.GetId())
 
-	mechanisms.SetMTUOverhead(parameters, srv6.MTUOverhead)
+	mechanisms.SetMTUOverhead(m, srv6.MTUOverhead)
 	return m
 }
 
@@ -179,7 +179,7 @@ func (cce *forwarderService) prepareWireguardMechanism(m *connection.Mechanism, 
 
 	parameters[wireguard.SrcPort] = wireguard.AssignPort(request.Connection.Id)
 
-	mechanisms.SetMTUOverhead(parameters, wireguard.MTUOverhead)
+	mechanisms.SetMTUOverhead(m, wireguard.MTUOverhead)
 	return m
 }
 

--- a/controlplane/pkg/local/forwarder_service.go
+++ b/controlplane/pkg/local/forwarder_service.go
@@ -25,6 +25,7 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
+	mechanisms "github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/common"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/srv6"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/wireguard"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/crossconnect"
@@ -152,10 +153,12 @@ func (cce *forwarderService) prepareSRv6Mechanism(m *connection.Mechanism, reque
 	parameters := m.GetParameters()
 	if parameters == nil {
 		parameters = map[string]string{}
+		m.Parameters = parameters
 	}
 	parameters[srv6.SrcBSID] = cce.serviceRegistry.SIDAllocator().SID(request.Connection.GetId())
 	parameters[srv6.SrcLocalSID] = cce.serviceRegistry.SIDAllocator().SID(request.Connection.GetId())
-	m.Parameters = parameters
+
+	mechanisms.SetMTUOverhead(parameters, srv6.MTUOverhead)
 	return m
 }
 
@@ -163,6 +166,7 @@ func (cce *forwarderService) prepareWireguardMechanism(m *connection.Mechanism, 
 	parameters := m.GetParameters()
 	if parameters == nil {
 		parameters = map[string]string{}
+		m.Parameters = parameters
 	}
 
 	key, err := wgtypes.GeneratePrivateKey()
@@ -175,6 +179,7 @@ func (cce *forwarderService) prepareWireguardMechanism(m *connection.Mechanism, 
 
 	parameters[wireguard.SrcPort] = wireguard.AssignPort(request.Connection.Id)
 
+	mechanisms.SetMTUOverhead(parameters, wireguard.MTUOverhead)
 	return m
 }
 

--- a/controlplane/pkg/remote/forwarder_service.go
+++ b/controlplane/pkg/remote/forwarder_service.go
@@ -153,7 +153,7 @@ func (cce *forwarderService) configureVXLANParameters(parameters, dpParameters m
 
 	parameters[vxlan.VNI] = strconv.FormatUint(uint64(vni), 10)
 
-	mechanisms.SetMTUOverhead(parameters, vxlan.MTUOverhead)
+	mechanisms.SetMTUOverheadParameter(parameters, vxlan.MTUOverhead)
 }
 
 func (cce *forwarderService) configureSRv6Parameters(connectionID string, parameters, dpParameters map[string]string) {
@@ -162,7 +162,7 @@ func (cce *forwarderService) configureSRv6Parameters(connectionID string, parame
 	parameters[srv6.DstHostLocalSID] = dpParameters[srv6.SrcHostLocalSID]
 	parameters[srv6.DstBSID] = cce.serviceRegistry.SIDAllocator().SID(connectionID)
 	parameters[srv6.DstLocalSID] = cce.serviceRegistry.SIDAllocator().SID(connectionID)
-	mechanisms.SetMTUOverhead(parameters, srv6.MTUOverhead)
+	mechanisms.SetMTUOverheadParameter(parameters, srv6.MTUOverhead)
 }
 
 func (cce *forwarderService) configureWireguardParameters(connectionID string, parameters, dpParameters map[string]string) {
@@ -178,7 +178,7 @@ func (cce *forwarderService) configureWireguardParameters(connectionID string, p
 
 	parameters[wireguard.DstPort] = wireguard.AssignPort(connectionID)
 
-	mechanisms.SetMTUOverhead(parameters, wireguard.MTUOverhead)
+	mechanisms.SetMTUOverheadParameter(parameters, wireguard.MTUOverhead)
 }
 
 func (cce *forwarderService) updateMechanism(request *networkservice.NetworkServiceRequest, dp *model.Forwarder) error {

--- a/controlplane/pkg/remote/forwarder_service.go
+++ b/controlplane/pkg/remote/forwarder_service.go
@@ -26,6 +26,7 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
+	mechanisms "github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/common"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/srv6"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/vxlan"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/wireguard"
@@ -151,6 +152,8 @@ func (cce *forwarderService) configureVXLANParameters(parameters, dpParameters m
 	}
 
 	parameters[vxlan.VNI] = strconv.FormatUint(uint64(vni), 10)
+
+	mechanisms.SetMTUOverhead(parameters, vxlan.MTUOverhead)
 }
 
 func (cce *forwarderService) configureSRv6Parameters(connectionID string, parameters, dpParameters map[string]string) {
@@ -159,6 +162,7 @@ func (cce *forwarderService) configureSRv6Parameters(connectionID string, parame
 	parameters[srv6.DstHostLocalSID] = dpParameters[srv6.SrcHostLocalSID]
 	parameters[srv6.DstBSID] = cce.serviceRegistry.SIDAllocator().SID(connectionID)
 	parameters[srv6.DstLocalSID] = cce.serviceRegistry.SIDAllocator().SID(connectionID)
+	mechanisms.SetMTUOverhead(parameters, srv6.MTUOverhead)
 }
 
 func (cce *forwarderService) configureWireguardParameters(connectionID string, parameters, dpParameters map[string]string) {
@@ -173,6 +177,8 @@ func (cce *forwarderService) configureWireguardParameters(connectionID string, p
 	parameters[wireguard.DstPublicKey] = key.PublicKey().String()
 
 	parameters[wireguard.DstPort] = wireguard.AssignPort(connectionID)
+
+	mechanisms.SetMTUOverhead(parameters, wireguard.MTUOverhead)
 }
 
 func (cce *forwarderService) updateMechanism(request *networkservice.NetworkServiceRequest, dp *model.Forwarder) error {

--- a/forwarder/pkg/common/egress_interface.go
+++ b/forwarder/pkg/common/egress_interface.go
@@ -42,6 +42,7 @@ type EgressInterfaceType interface {
 	Interface() *net.Interface
 	Name() string
 	HardwareAddr() *net.HardwareAddr
+	MTU() uint32
 	OutgoingInterface() string
 	ArpEntries() []*ARPEntry
 }
@@ -270,6 +271,13 @@ func (e *egressInterface) HardwareAddr() *net.HardwareAddr {
 		return nil
 	}
 	return &e.Interface().HardwareAddr
+}
+
+func (e *egressInterface) MTU() uint32 {
+	if e == nil {
+		return 0
+	}
+	return uint32(e.Interface().MTU)
 }
 
 func (e *egressInterface) OutgoingInterface() string {

--- a/forwarder/sdk/vppagent/kernel_interfaces.go
+++ b/forwarder/sdk/vppagent/kernel_interfaces.go
@@ -11,22 +11,25 @@ import (
 )
 
 //KernelInterfaces creates forwarder server handler with creation dataChange config for kernel and not direct memif connections
-func KernelInterfaces(baseDir string, baseMTU uint32) forwarder.ForwarderServer {
+func KernelInterfaces(baseDir string, baseMTU, mtuOverride uint32) forwarder.ForwarderServer {
 	return &kernelInterfaces{
-		baseDir: baseDir,
-		baseMTU: baseMTU,
+		baseDir:     baseDir,
+		baseMTU:     baseMTU,
+		mtuOverride: mtuOverride,
 	}
 }
 
 type kernelInterfaces struct {
-	baseDir string
-	baseMTU uint32
+	baseDir     string
+	baseMTU     uint32
+	mtuOverride uint32
 }
 
 func (c *kernelInterfaces) Request(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*crossconnect.CrossConnect, error) {
 	conversionParameters := &converter.CrossConnectConversionParameters{
-		BaseDir: c.baseDir,
-		BaseMTU: c.baseMTU,
+		BaseDir:     c.baseDir,
+		BaseMTU:     c.baseMTU,
+		MTUOverride: c.mtuOverride,
 	}
 	dataChange, err := converter.NewCrossConnectConverter(crossConnect, conversionParameters).ToDataRequest(nil, true)
 	if err != nil {

--- a/forwarder/sdk/vppagent/kernel_interfaces.go
+++ b/forwarder/sdk/vppagent/kernel_interfaces.go
@@ -11,25 +11,28 @@ import (
 )
 
 //KernelInterfaces creates forwarder server handler with creation dataChange config for kernel and not direct memif connections
-func KernelInterfaces(baseDir string, baseMTU, mtuOverride uint32) forwarder.ForwarderServer {
+func KernelInterfaces(baseDir string, baseMTU, mechanismMTUOverhead, mtuOverride uint32) forwarder.ForwarderServer {
 	return &kernelInterfaces{
-		baseDir:     baseDir,
-		baseMTU:     baseMTU,
-		mtuOverride: mtuOverride,
+		baseDir:              baseDir,
+		baseMTU:              baseMTU,
+		mechanismMTUOverhead: mechanismMTUOverhead,
+		mtuOverride:          mtuOverride,
 	}
 }
 
 type kernelInterfaces struct {
-	baseDir     string
-	baseMTU     uint32
-	mtuOverride uint32
+	baseDir              string
+	baseMTU              uint32
+	mechanismMTUOverhead uint32
+	mtuOverride          uint32
 }
 
 func (c *kernelInterfaces) Request(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*crossconnect.CrossConnect, error) {
 	conversionParameters := &converter.CrossConnectConversionParameters{
-		BaseDir:     c.baseDir,
-		BaseMTU:     c.baseMTU,
-		MTUOverride: c.mtuOverride,
+		BaseDir:              c.baseDir,
+		BaseMTU:              c.baseMTU,
+		MechanismMTUOverhead: c.mechanismMTUOverhead,
+		MTUOverride:          c.mtuOverride,
 	}
 	dataChange, err := converter.NewCrossConnectConverter(crossConnect, conversionParameters).ToDataRequest(nil, true)
 	if err != nil {

--- a/forwarder/sdk/vppagent/kernel_interfaces.go
+++ b/forwarder/sdk/vppagent/kernel_interfaces.go
@@ -11,17 +11,22 @@ import (
 )
 
 //KernelInterfaces creates forwarder server handler with creation dataChange config for kernel and not direct memif connections
-func KernelInterfaces(baseDir string) forwarder.ForwarderServer {
-	return &kernelInterfaces{baseDir: baseDir}
+func KernelInterfaces(baseDir string, baseMTU uint32) forwarder.ForwarderServer {
+	return &kernelInterfaces{
+		baseDir: baseDir,
+		baseMTU: baseMTU,
+	}
 }
 
 type kernelInterfaces struct {
 	baseDir string
+	baseMTU uint32
 }
 
 func (c *kernelInterfaces) Request(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*crossconnect.CrossConnect, error) {
 	conversionParameters := &converter.CrossConnectConversionParameters{
 		BaseDir: c.baseDir,
+		BaseMTU: c.baseMTU,
 	}
 	dataChange, err := converter.NewCrossConnectConverter(crossConnect, conversionParameters).ToDataRequest(nil, true)
 	if err != nil {

--- a/forwarder/vppagent/pkg/converter/converter.go
+++ b/forwarder/vppagent/pkg/converter/converter.go
@@ -8,6 +8,7 @@ type Converter interface {
 
 type CrossConnectConversionParameters struct {
 	BaseDir string
+	BaseMTU uint32
 }
 
 type ConnectionContextSide int
@@ -23,4 +24,5 @@ type ConnectionConversionParameters struct {
 	Side      ConnectionContextSide
 	Name      string
 	BaseDir   string
+	MTU       uint32
 }

--- a/forwarder/vppagent/pkg/converter/converter.go
+++ b/forwarder/vppagent/pkg/converter/converter.go
@@ -7,8 +7,9 @@ type Converter interface {
 }
 
 type CrossConnectConversionParameters struct {
-	BaseDir string
-	BaseMTU uint32
+	BaseDir     string
+	BaseMTU     uint32
+	MTUOverride uint32
 }
 
 type ConnectionContextSide int

--- a/forwarder/vppagent/pkg/converter/converter.go
+++ b/forwarder/vppagent/pkg/converter/converter.go
@@ -7,9 +7,10 @@ type Converter interface {
 }
 
 type CrossConnectConversionParameters struct {
-	BaseDir     string
-	BaseMTU     uint32
-	MTUOverride uint32
+	BaseDir              string
+	BaseMTU              uint32 // base MTU to be applied = MTU of the egress interface
+	MechanismMTUOverhead uint32 // maximum MTU overhead of all the supported mechanism types
+	MTUOverride          uint32 // specific MTU that overrides automatic MTU calculation
 }
 
 type ConnectionContextSide int

--- a/forwarder/vppagent/pkg/converter/cross_connect_converter.go
+++ b/forwarder/vppagent/pkg/converter/cross_connect_converter.go
@@ -138,6 +138,9 @@ func (c *CrossConnectConverter) MechanismsToDataRequest(rv *configurator.Config,
 
 // calculateInterfaceMTU returns the proper MTU to be applied on xconnect interfaces
 func (c *CrossConnectConverter) calculateInterfaceMTU() uint32 {
+	if c.conversionParameters.MTUOverride != 0 {
+		return c.conversionParameters.MTUOverride
+	}
 	if c.conversionParameters.BaseMTU == 0 {
 		return 0 // MTU 0 in vppagent API means undefined
 	}

--- a/forwarder/vppagent/pkg/converter/cross_connect_converter.go
+++ b/forwarder/vppagent/pkg/converter/cross_connect_converter.go
@@ -143,10 +143,10 @@ func (c *CrossConnectConverter) calculateInterfaceMTU() uint32 {
 	}
 	// find the largest MTU overhead from both src/dst mechanisms and src/dst extra contexts
 	overheads := make([]uint32, 4)
-	overheads[0], _ = common.GetMTUOverhead(c.Source.GetMechanism().GetParameters())
-	overheads[1], _ = common.GetMTUOverhead(c.Destination.GetMechanism().GetParameters())
-	overheads[2], _ = common.GetMTUOverhead(c.Source.GetContext().GetExtraContext())
-	overheads[3], _ = common.GetMTUOverhead(c.Destination.GetContext().GetExtraContext())
+	overheads[0], _ = common.GetMTUOverhead(c.Source.GetMechanism())
+	overheads[1], _ = common.GetMTUOverhead(c.Destination.GetMechanism())
+	overheads[2], _ = c.Source.GetContext().GetMTUOverhead()
+	overheads[3], _ = c.Destination.GetContext().GetMTUOverhead()
 	maxOverhead := uint32(0)
 	for _, o := range overheads {
 		if o > maxOverhead {

--- a/forwarder/vppagent/pkg/converter/kernel_connection_converter.go
+++ b/forwarder/vppagent/pkg/converter/kernel_connection_converter.go
@@ -86,7 +86,7 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 			Name:    c.conversionParameters.Name,
 			Type:    vpp_interfaces.Interface_TAP,
 			Enabled: true,
-			Mtu:     1450,
+			Mtu:     c.conversionParameters.MTU,
 			Link: &vpp_interfaces.Interface_Tap{
 				Tap: &vpp_interfaces.TapLink{
 					Version: 2,
@@ -104,7 +104,7 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 			IpAddresses: ipAddresses,
 			PhysAddress: mac,
 			HostIfName:  m.GetParameters()[common.InterfaceNameKey],
-			Mtu:         1450,
+			Mtu:         c.conversionParameters.MTU,
 			Namespace: &linux_namespace.NetNamespace{
 				Type:      linux_namespace.NetNamespace_FD,
 				Reference: filepath,
@@ -122,7 +122,7 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 			Type:       linux_interfaces.Interface_VETH,
 			Enabled:    true,
 			HostIfName: c.conversionParameters.Name + "-veth",
-			Mtu:        1450,
+			Mtu:        c.conversionParameters.MTU,
 			Link: &linux_interfaces.Interface_Veth{
 				Veth: &linux_interfaces.VethLink{
 					PeerIfName:           c.conversionParameters.Name,
@@ -138,7 +138,7 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 			IpAddresses: ipAddresses,
 			PhysAddress: mac,
 			HostIfName:  m.GetParameters()[common.InterfaceNameKey],
-			Mtu:         1450,
+			Mtu:         c.conversionParameters.MTU,
 			Namespace: &linux_namespace.NetNamespace{
 				Type:      linux_namespace.NetNamespace_FD,
 				Reference: filepath,
@@ -155,7 +155,7 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 			Name:    c.conversionParameters.Name,
 			Type:    vpp_interfaces.Interface_AF_PACKET,
 			Enabled: true,
-			Mtu:     1450,
+			Mtu:     c.conversionParameters.MTU,
 			Link: &vpp_interfaces.Interface_Afpacket{
 				Afpacket: &vpp_interfaces.AfpacketLink{
 					LinuxInterface: c.conversionParameters.Name + "-veth",

--- a/forwarder/vppagent/pkg/converter/memif_interface_converter.go
+++ b/forwarder/vppagent/pkg/converter/memif_interface_converter.go
@@ -83,7 +83,7 @@ func (c *MemifInterfaceConverter) ToDataRequest(rv *configurator.Config, connect
 		Type:        vpp_interfaces.Interface_MEMIF,
 		Enabled:     true,
 		IpAddresses: ipAddresses,
-		Mtu:         1450,
+		Mtu:         c.conversionParameters.MTU,
 		Link: &vpp_interfaces.Interface_Memif{
 			Memif: &vpp_interfaces.MemifLink{
 				Master:         isMaster,

--- a/forwarder/vppagent/pkg/vppagent/vppagent.go
+++ b/forwarder/vppagent/pkg/vppagent/vppagent.go
@@ -68,7 +68,7 @@ func (v *VPPAgent) CreateForwarderServer(config *common.ForwarderConfig) forward
 		sdk.UseCrossConnectMonitor(config.Monitor),
 		sdk.DirectMemifInterfaces(config.NSMBaseDir),
 		sdk.Connect(v.endpoint()),
-		sdk.KernelInterfaces(config.NSMBaseDir, config.EgressInterface.MTU()),
+		sdk.KernelInterfaces(config.NSMBaseDir, config.EgressInterface.MTU(), config.ConnectionMTUOverride),
 		sdk.UseEthernetContext(),
 		sdk.ClearMechanisms(config.NSMBaseDir),
 		sdk.Commit(v.downstreamResync))

--- a/forwarder/vppagent/pkg/vppagent/vppagent.go
+++ b/forwarder/vppagent/pkg/vppagent/vppagent.go
@@ -68,7 +68,7 @@ func (v *VPPAgent) CreateForwarderServer(config *common.ForwarderConfig) forward
 		sdk.UseCrossConnectMonitor(config.Monitor),
 		sdk.DirectMemifInterfaces(config.NSMBaseDir),
 		sdk.Connect(v.endpoint()),
-		sdk.KernelInterfaces(config.NSMBaseDir),
+		sdk.KernelInterfaces(config.NSMBaseDir, config.EgressInterface.MTU()),
 		sdk.UseEthernetContext(),
 		sdk.ClearMechanisms(config.NSMBaseDir),
 		sdk.Commit(v.downstreamResync))


### PR DESCRIPTION
This PR adds the ability to properly set client interface MTU:
 - each local/remote connection mechanism can specify its MTU overhead
 - NSE can set its MTU overhead in the connection context (e.g. `request.Connection.Context.SetMTUOverhead(50)`)
 - the forwarder will substract the largest MTU overhead in used mechanisms and connection context from the MTU discovered on the egress interface
- the resulting MTU is applied on the client interface