### PR TITLE
Export forwarder MTU override in helm chart

### DIFF
--- a/deployments/helm/nsm/templates/forwarding-plane.tpl
+++ b/deployments/helm/nsm/templates/forwarding-plane.tpl
@@ -35,6 +35,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            {{- if .Values.vpp.mtuOverride }}
+            - name: NSM_CONNECTION_MTU_OVERRIDE
+              value: {{ .Values.vpp.mtuOverride | quote }}
+            {{- end }}
           volumeMounts:
             - name: workspace
               mountPath: /var/lib/networkservicemesh/

--- a/deployments/helm/nsm/values.yaml
+++ b/deployments/helm/nsm/values.yaml
@@ -14,6 +14,7 @@ preferredRemoteMechanism:
 
 vpp:
   image: vppagent-forwarder
+  mtuOverride:
 
 kernel:
   image: kernel-forwarder


### PR DESCRIPTION
Forwarder MTU override exported as `vpp.mtuOverride` helm option. E.g. the result of the deployment with:
```
helm template ${NSMDIR}/deployments/helm/nsm --namespace nsm-system --set vpp.mtuOverride=1400 ...
```

is:
```
$ kubectl --context kind-kind-2 exec -it helloworld-example-6498d6c745-hdnt7 -- ip addr
Defaulting container name to helloworld.
Use 'kubectl describe pod/helloworld-example-6498d6c745-hdnt7 -n default' to see all of the containers in this pod.
21: nsm0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc mq state UNKNOWN group default qlen 1000
    link/ether 02:fe:d9:f9:25:d9 brd ff:ff:ff:ff:ff:ff
    inet 172.31.252.9/30 brd 172.31.252.11 scope global nsm0
       valid_lft forever preferred_lft forever
    inet6 fe80::fe:d9ff:fef9:25d9/64 scope link 
       valid_lft forever preferred_lft forever
```