### PR TITLE
vpp fowarder: change memif from polling to interupt mode and ring size 512

### DIFF
--- a/forwarder/vppagent/pkg/converter/memif_interface_converter.go
+++ b/forwarder/vppagent/pkg/converter/memif_interface_converter.go
@@ -84,10 +84,17 @@ func (c *MemifInterfaceConverter) ToDataRequest(rv *configurator.Config, connect
 		Enabled:     true,
 		IpAddresses: ipAddresses,
 		Mtu:         c.conversionParameters.MTU,
+		RxModes: []*vpp_interfaces.Interface_RxMode{
+			{
+				Mode:        vpp_interfaces.Interface_RxMode_INTERRUPT,
+				DefaultMode: true,
+			},
+		},
 		Link: &vpp_interfaces.Interface_Memif{
 			Memif: &vpp_interfaces.MemifLink{
 				Master:         isMaster,
 				SocketFilename: path.Join(fullyQualifiedSocketFilename),
+				RingSize:       512,
 			},
 		},
 	})


### PR DESCRIPTION
Change memif mode to interrupt and adjust the ring size to avoid race conditions as the number of client interfaces scale.