### PR TITLE
Make proxy-nsmgr non-daemonset in NSM helm chart

### DIFF
--- a/deployments/helm/proxy-nsmgr/templates/proxy-nsmgr.tpl
+++ b/deployments/helm/proxy-nsmgr/templates/proxy-nsmgr.tpl
@@ -5,6 +5,7 @@ metadata:
   name: proxy-nsmgr
   namespace: {{ .Release.Namespace }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: proxy-nsmgr-deployment

--- a/deployments/helm/proxy-nsmgr/templates/proxy-nsmgr.tpl
+++ b/deployments/helm/proxy-nsmgr/templates/proxy-nsmgr.tpl
@@ -1,17 +1,17 @@
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: proxy-nsmgr
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: proxy-nsmgr-daemonset
+      app: proxy-nsmgr-deployment
   template:
     metadata:
       labels:
-        app: proxy-nsmgr-daemonset
+        app: proxy-nsmgr-deployment
     spec:
       serviceAccount: proxy-nsmgr-acc
       containers:
@@ -66,7 +66,7 @@ kind: Service
 metadata:
   name: pnsmgr-svc
   labels:
-    app: proxy-nsmgr-daemonset
+    app: proxy-nsmgr-deployment
   namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
@@ -80,4 +80,4 @@ spec:
       nodePort: 31506
       protocol: TCP
   selector:
-    app: proxy-nsmgr-daemonset
+    app: proxy-nsmgr-deployment

--- a/deployments/helm/proxy-nsmgr/values.yaml
+++ b/deployments/helm/proxy-nsmgr/values.yaml
@@ -14,4 +14,4 @@ global:
   # set to true to enable Jaeger tracing for NSM components
   JaegerTracing: false
 
-  replicaCount: 1
+replicaCount: 1

--- a/deployments/helm/proxy-nsmgr/values.yaml
+++ b/deployments/helm/proxy-nsmgr/values.yaml
@@ -13,3 +13,5 @@ remoteNsrPort: 5005
 global:
   # set to true to enable Jaeger tracing for NSM components
   JaegerTracing: false
+
+  replicaCount: 1

--- a/docs/spec/proxy-nsmgr.md
+++ b/docs/spec/proxy-nsmgr.md
@@ -29,18 +29,18 @@ Following is an example of the full Proxy NSMgr deployment.
 ```yaml
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: proxy-nsmgr
   namespace: nsm-system
 spec:
   selector:
     matchLabels:
-      app: proxy-nsmgr-daemonset
+      app: proxy-nsmgr-deployment
   template:
     metadata:
       labels:
-        app: proxy-nsmgr-daemonset
+        app: proxy-nsmgr-deployment
     spec:
       containers:
         - name: proxy-nsmd
@@ -66,7 +66,7 @@ kind: Service
 metadata:
   name: pnsmgr-svc
   labels:
-    app: proxy-nsmgr-daemonset
+    app: proxy-nsmgr-deployment
   namespace: nsm-system
 spec:
   ports:
@@ -77,7 +77,7 @@ spec:
       port: 5006
       protocol: TCP
   selector:
-    app: proxy-nsmgr-daemonset
+    app: proxy-nsmgr-deployment
 
 ```
 


### PR DESCRIPTION
## Summary
<!--- Provide a general summary of your changes in the Title above -->
Change the proxy-nsmgr to be a deployment rather than a daemonset to recude the complexity and overhead of NSM installations.

## Description
<!--- Describe your changes in detail -->
- This is for acceptance criteria 2 of NSMNSE-21: https://jira-eng-sjc4.cisco.com/jira/browse/NSMNSE-21
- All reference of "proxy-nsmgr-daemonset" has been updated to "proxy-nsmgr-deployment"  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [x] Have not tested
<!--- Add additional comments about testing if needed. -->
No existing test cases found for this NSM helm chart, it seems the proxy-nsmgr is no longer deployed by this NSM helm chart.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
